### PR TITLE
Updated permission classes in GetAPI view  Changed permission_classes…

### DIFF
--- a/API/views.py
+++ b/API/views.py
@@ -1,8 +1,10 @@
 from .serializer import APIserializers
 from django.shortcuts import render
 from rest_framework import generics
+from rest_framework.permissions import IsAdminUser
 from .models import API
 # Create your views here.
 class GetAPI(generics.ListAPIView):
     queryset = API.objects.all()
     serializer_class = APIserializers
+    permission_classes = (IsAdminUser,)


### PR DESCRIPTION
… attribute in the GetAPI view to restrict access to only admin users.

 Updated the permission_classes attribute in the GetAPI view to restrict access to only admin users. This change was made to enhance the security of the API endpoint and ensure that only authorized users can access sensitive data.